### PR TITLE
make transmute_float_to_int function unsafe

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -414,7 +414,7 @@ impl Hash for Literal {
             Literal::Int(i) => { state.write_i32(*i) }
             Literal::Float(i) => {
                 // Floats have edge cases for hash computation, I ignore those cases for simplicity
-                state.write_i32(transmute_float_to_int(*i))
+                state.write_i32(unsafe { transmute_float_to_int(*i) })
             }
             Literal::String(i) => { i.hash(state) }
             Literal::Char(i) => { state.write_u32(*i as u32) }

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,7 +139,7 @@ impl Hash for Value {
             Value::Unit => { state.write_i32(0) }
             Value::Number(i) => { state.write_i32(*i) }
             Value::Int(i) => { state.write_i32(*i) }
-            Value::Float(i) => { state.write_i32(transmute_float_to_int(*i)) }
+            Value::Float(i) => { state.write_i32(unsafe { transmute_float_to_int(*i) }) }
             Value::String(i) => { i.hash(state) }
             Value::Char(i) => { state.write_u32(*i as u32) }
             Value::List(i) => { i.hash(state) }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -204,6 +204,6 @@ pub fn resource_path(path: &str) -> String {
     d.to_string_lossy().to_string()
 }
 
-pub fn transmute_float_to_int(x: f32) -> i32 {
-    unsafe { transmute::<f32, i32>(x) }
+pub unsafe fn transmute_float_to_int(x: f32) -> i32 {
+    transmute::<f32, i32>(x) 
 }


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/cout970/Elm-interpreter/blob/8ddd0b90f70e1e7c89775c7a9854fbd91b5124c6/src/util/mod.rs#L207-L209

It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the transmute_float_to_int function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.